### PR TITLE
修复内存泄露

### DIFF
--- a/XLPageViewControllerExample/XLPageViewController/XLPageViewController.m
+++ b/XLPageViewControllerExample/XLPageViewController/XLPageViewController.m
@@ -136,7 +136,7 @@ typedef void(^XLContentScollBlock)(BOOL scrollEnabled);
     
     //兼容全屏返回手势识别
     self.scrollView.xl_otherGestureRecognizerBlock = ^BOOL(UIGestureRecognizer * _Nonnull otherGestureRecognizer) {
-        return weakSelf.selectedIndex == 0 && [self.respondOtherGestureDelegateClassList containsObject:NSStringFromClass(otherGestureRecognizer.delegate.class)];
+        return weakSelf.selectedIndex == 0 && [weakSelf.respondOtherGestureDelegateClassList containsObject:NSStringFromClass(otherGestureRecognizer.delegate.class)];
     };
 }
 


### PR DESCRIPTION
使用过程中发现控制器无法释放，看了源码，是在兼容全屏返回手势的block里强引用了`self`。做了修改。